### PR TITLE
Create zone & create channel updates

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -34,3 +34,6 @@ export const ceilTime = (time: Date | string | number, minutes = 30): Date => {
   );
   return timeToReturn;
 };
+
+export const nameToSubdomain = (name: string): string =>
+  name.toLowerCase().replaceAll(' ', '-');

--- a/src/layers/create-channel/CreateChannel.tsx
+++ b/src/layers/create-channel/CreateChannel.tsx
@@ -32,17 +32,18 @@ const CreateChannel: FC<CreateChannelProps> = ({ onDismiss }) => {
     zone: {
       getZoneCategories: { categories },
       getUserZones: { userZones },
+      selectedUserZone,
     },
   } = useSelector((state: AppState) => state);
   const size = useContext(ResponsiveContext);
-  const [userZone, setUserZone] = useState();
+  const [userZone, setUserZone] = useState<any>(selectedUserZone?.id);
   const [category, setCategory] = useState();
   const [name, setName] = useState('');
   const [topic, setTopic] = useState('');
   const [description, setDescription] = useState('');
   const [publicChannel, setPublicChannel] = useState(true);
 
-  const notValid = !name || !description || !topic || !category || !userZone;
+  const notValid = !name || !description || !topic || !userZone;
 
   return (
     <Layer onClickOutside={onDismiss}>
@@ -97,17 +98,6 @@ const CreateChannel: FC<CreateChannelProps> = ({ onDismiss }) => {
                   name="description"
                 />
               </FormField>
-              <FormField name="public">
-                <CheckBox
-                  toggle
-                  label="Public"
-                  name="public"
-                  checked={publicChannel}
-                  onChange={(e) => {
-                    setPublicChannel(e.target.checked);
-                  }}
-                />
-              </FormField>
               <FormField required name="zoneId" label="Zone">
                 <Select
                   name="zoneId"
@@ -131,7 +121,7 @@ const CreateChannel: FC<CreateChannelProps> = ({ onDismiss }) => {
                   }}
                 />
               </FormField>
-              <FormField required name="categoryId" label="Category">
+              <FormField name="categoryId" label="Category">
                 <Select
                   options={categories || []}
                   disabled={!userZone}
@@ -141,6 +131,17 @@ const CreateChannel: FC<CreateChannelProps> = ({ onDismiss }) => {
                   valueKey={{ key: 'id', reduce: true }}
                   value={category}
                   onChange={({ value }) => setCategory(value)}
+                />
+              </FormField>
+              <FormField name="public">
+                <CheckBox
+                  toggle
+                  label="Public"
+                  name="public"
+                  checked={publicChannel}
+                  onChange={(e) => {
+                    setPublicChannel(e.target.checked);
+                  }}
                 />
               </FormField>
             </Box>

--- a/src/layers/create-zone/CreateZone.tsx
+++ b/src/layers/create-zone/CreateZone.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../store/actions/zone.action';
 import { AppState } from '../../store/reducers/root.reducer';
 import { CreateZonePayload } from '../../store/types/zone.types';
+import { nameToSubdomain } from '../../helpers/utils';
 
 interface CreateZoneProps {
   onDismiss: () => void;
@@ -37,6 +38,7 @@ const CreateZone: FC<CreateZoneProps> = ({ onDismiss }) => {
 
   const [name, setName] = useState('');
   const [subdomain, setSubdomain] = useState('');
+  const [subdomainInputFocus, setSubdomainInputFocus] = useState(false);
   const [description, setDescription] = useState('');
   const [publicZone, setPublicZone] = useState(true);
   const [category, setCategory] = useState();
@@ -80,18 +82,25 @@ const CreateZone: FC<CreateZoneProps> = ({ onDismiss }) => {
                 <FormField required name="name" label="Name">
                   <TextInput
                     value={name}
-                    onChange={(e) => {
-                      setName(e.target.value);
+                    onChange={({ target: { value } }) => {
+                      setName(value);
+                      setSubdomain(nameToSubdomain(value));
                     }}
                     name="name"
                   />
                 </FormField>
-                <FormField required name="subdomain" label="Subdomain">
+                <FormField required name="subdomain" label="Zone Address">
                   <TextInput
-                    value={subdomain}
+                    value={
+                      subdomainInputFocus || !subdomain
+                        ? subdomain
+                        : `${subdomain}.octopus.com`
+                    }
                     onChange={(e) => {
                       setSubdomain(e.target.value);
                     }}
+                    onFocus={() => setSubdomainInputFocus(true)}
+                    onBlur={() => setSubdomainInputFocus(false)}
                     name="subdomain"
                   />
                 </FormField>
@@ -102,17 +111,6 @@ const CreateZone: FC<CreateZoneProps> = ({ onDismiss }) => {
                       setDescription(e.target.value);
                     }}
                     name="description"
-                  />
-                </FormField>
-                <FormField name="public">
-                  <CheckBox
-                    toggle
-                    checked={publicZone}
-                    onChange={(e) => {
-                      setPublicZone(e.target.checked);
-                    }}
-                    label="Public"
-                    name="public"
                   />
                 </FormField>
                 <FormField required name="categoryId" label="Category">
@@ -126,6 +124,17 @@ const CreateZone: FC<CreateZoneProps> = ({ onDismiss }) => {
                     onChange={({ option }) => {
                       setCategory(option.id);
                     }}
+                  />
+                </FormField>
+                <FormField name="public">
+                  <CheckBox
+                    toggle
+                    checked={publicZone}
+                    onChange={(e) => {
+                      setPublicZone(e.target.checked);
+                    }}
+                    label="Public"
+                    name="public"
                   />
                 </FormField>
               </Box>


### PR DESCRIPTION
- Subdomain label rename to address
- Generate default address from name
- `.octopus.com` append to address input field when not on focus (I couldn't find a way to do it while typing with Grommet options)
- If user is already in a zone, that zone is auto selected on Create a channel window
- Category is made optional on Create a channel
- Public toggles relocated to the bottom of the list on both Create a channel & Create a zone layers