### PR TITLE
Maximum Body Size changed to 500Mb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ REACT_APP_SERVER_HOST=http://octopus.localhost:8000
 REACT_APP_CLIENT_HOST=http://octopus.localhost:3000
 VIDEO_VIEW_COUNT_HOUR_INTERVAL=12
 REACT_APP_STREAMING_URL=https://octopus-jitsi.doganbros.com:1980/hls
+HTTP_MAX_BODY_SIZE=500mb
+
 
 #User Authentication
 AUTH_TOKEN_LIFE=1h

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -7,17 +7,19 @@ import { initApp } from 'populators/init-app';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { json } from 'express';
 import { AppModule } from './app.module';
 
 initApp();
 
-const { REACT_APP_CLIENT_HOST } = process.env;
+const { REACT_APP_CLIENT_HOST, HTTP_MAX_BODY_SIZE } = process.env;
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.use(morgan(process.env.NODE_ENV === 'development' ? 'dev' : 'combined'));
   app.enableVersioning();
   app.use(helmet());
+  app.use(json({ limit: HTTP_MAX_BODY_SIZE || '500mb' }));
   const originRegex = new RegExp(
     `(\\b|\\.)${new URL(REACT_APP_CLIENT_HOST as string).host.replace(
       /\./g,


### PR DESCRIPTION
backend max body size for requests is set to 500mb default. It can be configured with env param **HTTP_MAX_BODY_SIZE**

Also we may need to update nginx config. Set max body size for purpie.io to 500mb or else.